### PR TITLE
🚑 [Hotfix] SSH keepalive 설정 추가로 배포 중 Broken pipe 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,8 @@ jobs:
             IdentityFile ~/.ssh/scenepick.key
             ProxyJump bastion
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
           EOF
 
       - name: Deploy manifests to k3s


### PR DESCRIPTION
### 🔗 관련 이슈 (Linked Issues)
fix #45 

### 🏷️ 작업 유형 (Task Types)

- [ ] ✨ **Feat**: New feature implementation
- [x] 🐛 **Fix**: Bug fix
- [ ] 🎨 **Style**: Code style changes (Checkstyle, formatting)
- [ ] 📝 **Docs**: Documentation updates (README, Swagger, etc.)
- [ ] ♻️ **Refactor**: Code refactoring (no functional changes)
- [ ] 🧪 **Test**: Adding or updating tests
- [ ] ⚙️ **Setting**: Project configuration (build.gradle, yml, etc.)
- [ ] 🚀 **Chore**: Miscellaneous or routine maintenance tasks

## 문제
  `kubectl rollout status`가 배포 완료를 기다리는 동안 (최대 5분) SSH 연결이 idle timeout으로 끊겨 `Broken pipe` + exit 255 오류 발생

  ## 원인
  SSH 설정에 keepalive 옵션이 없어 bastion/master 서버가 먼저 연결을 종료

  ## 해결
  SSH config의 master 호스트에 keepalive 옵션 추가
  - `ServerAliveInterval 30`: 30초마다 keepalive 패킷 전송
  - `ServerAliveCountMax 20`: 최대 600초(10분) 연결 유지 → 롤아웃 타임아웃(5분) 커버

### ✅ 셀프 체크리스트 (Self-Checklist)

- [x] PR 컨벤션에 맞게 작성했습니다.
- [x] commit convention을 지켰습니다.
- [x] Issue를 생성하고, Issue 번호에 맞는 브랜치를 생성했습니다.
- [x] Issue 컨벤션에 맞게 Issue를 생성했습니다.


